### PR TITLE
fix bug with nested object property using as ng-model

### DIFF
--- a/angular-clear-input.js
+++ b/angular-clear-input.js
@@ -8,7 +8,7 @@ angular.module('dcbClearInput', [])
             return {
                 restrict: 'A',
                 require: 'ngModel',
-                link: function(scope, element, attr) {
+                link: function(scope, element, attr, ngModel) {
                     var htmlMarkup = attr.clearBtnMarkup ? attr.clearBtnMarkup : '<span>&times;</span>';
                     var btn = angular.element(htmlMarkup);
                     btn.addClass(attr.clearBtnClass ? attr.clearBtnClass : "clear-btn");
@@ -23,8 +23,8 @@ angular.module('dcbClearInput', [])
                                 });
                             });
                         } else {
-                            scope[attr.ngModel] = null;
-                            scope.$digest();
+                            ngModel.$setViewValue(null);
+                            ngModel.$render();
                         }
                     });
 


### PR DESCRIPTION
Hi Guys,

i am using the angular clear input directive and run into problems with nested object property as ng-model values (e.g ng-model="foo.bar"). The current behavior adds a new value on the scope with name "foo.bar" instead of modifing the nested property "bar" of the object "foo". Using the required ngModel controller fixes this misbehavior.

Kind regards 
Marko